### PR TITLE
Fix SWRI scraper output directory handling

### DIFF
--- a/sites/swri.py
+++ b/sites/swri.py
@@ -6,12 +6,17 @@ from selenium.webdriver.support import expected_conditions as EC
 from bs4 import BeautifulSoup
 
 def fetch_jobs():
-    # Define the list of keywords to search for
+    """Scrape Southwest Research Institute job postings."""
+
+    # Keywords used to filter relevant job postings
     keywords = ["embedded", "software", "automotive"]
 
     # Set up the Selenium WebDriver (ensure the appropriate driver is installed)
     driver = webdriver.Chrome()  # or webdriver.Firefox(), etc.
     driver.get("https://resapp.swri.org/ResApp/Job_Search.aspx")
+
+    jobs = []
+    all_titles = []  # To store all job titles for logging
 
     try:
         # Click the 'Search' button
@@ -25,8 +30,6 @@ def fetch_jobs():
 
         # Parse the page source with BeautifulSoup
         soup = BeautifulSoup(driver.page_source, "html.parser")
-        jobs = []
-        all_titles = []  # To store all job titles for logging
         for row in soup.select("table#tblHistory tr")[1:]:
             columns = row.find_all("td")
             if not columns:
@@ -38,21 +41,25 @@ def fetch_jobs():
             all_titles.append(title)  # Add title to the list
 
             # Check if any keyword is in the title or job description
-            if any(keyword.lower() in title.lower() or keyword.lower() in job_desc.lower() for keyword in keywords):
+            if any(
+                keyword.lower() in title.lower() or keyword.lower() in job_desc.lower()
+                for keyword in keywords
+            ):
                 jobs.append({"title": title, "url": link, "description": job_desc})
-
-        return jobs
 
     finally:
         driver.quit()
 
+        # Ensure the output directory exists before writing
+        os.makedirs("output", exist_ok=True)
+
         # Write all found job titles
-        with open(f"output/job_titles_swri.txt", "w", encoding="utf-8") as f:
+        with open("output/job_titles_swri.txt", "w", encoding="utf-8") as f:
             for title in all_titles:
                 f.write(title + "\n")
 
         # Write matching job results
-        with open(f"output/job_results_swri.txt", "w", encoding="utf-8") as f:
+        with open("output/job_results_swri.txt", "w", encoding="utf-8") as f:
             for job in jobs:
                 job_details = (
                     f"Title: {job['title']}\n"
@@ -60,3 +67,5 @@ def fetch_jobs():
                     f"Description: {job['description']}\n"
                 )
                 f.write(job_details + "\n")  # Write to file
+
+    return jobs


### PR DESCRIPTION
## Summary
- ensure SWRI output directory exists and variables are always defined
- update code comments and move return after cleanup

## Testing
- `python -m py_compile sites/swri.py`
- `python -m py_compile main.py sites/llmit.py sites/sri.py sites/lanl.py sites/umich.py utils/notifier.py`

------
https://chatgpt.com/codex/tasks/task_e_6847063de70c833286a6bfdd5f8f60b3