### PR TITLE
Add persistent job database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,4 +175,7 @@ cython_debug/
 
 output
 
+# persistent job database
+jobs_db.yaml
+
 .vscode

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ pip install requests beautifulsoup4 lxml plyer selenium pyyaml
 # Execution
 python main.py
 
+## Persistent Job Database
+Each run updates `jobs_db.yaml` with all discovered jobs. When new jobs are found
+during a run they are logged to the console. This makes it easy to see which
+postings you haven't reviewed yet.
+
 The output for each job fetcher is now written to `output/<site>_jobs.yaml`. Each
 YAML file contains two lists:
 

--- a/job_db.py
+++ b/job_db.py
@@ -1,0 +1,28 @@
+import os
+import yaml
+from typing import Dict, List
+
+DB_PATH = os.path.join(os.path.dirname(__file__), "jobs_db.yaml")
+
+
+def load_db() -> Dict[str, List[dict]]:
+    """Load the database from disk."""
+    if os.path.exists(DB_PATH):
+        with open(DB_PATH, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    return {}
+
+
+def save_db(db: Dict[str, List[dict]]) -> None:
+    """Persist the database to disk."""
+    with open(DB_PATH, "w", encoding="utf-8") as f:
+        yaml.dump(db, f, allow_unicode=True)
+
+
+def add_jobs(site: str, jobs: List[dict], db: Dict[str, List[dict]]) -> List[dict]:
+    """Add jobs for a site to the database and return the newly added ones."""
+    existing = {job["url"] for job in db.get(site, []) if "url" in job}
+    new_jobs = [job for job in jobs if job.get("url") not in existing]
+    if new_jobs:
+        db.setdefault(site, []).extend(new_jobs)
+    return new_jobs

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from sites import llmit
 import os
 import shutil
 import logging
+import job_db
 
 logging.basicConfig(
     level=logging.INFO,
@@ -21,12 +22,27 @@ def run_all():
     # Recreate the output directory
     os.makedirs(output_dir, exist_ok=True)
 
+    db = job_db.load_db()
+
+    sites = [
+        (lanl, "lanl"),
+        (sri, "sri"),
+        (llmit, "llmit"),
+        (swri, "swri"),
+        (umich, "umich"),
+    ]
+
     all_jobs = []
-    all_jobs.extend(lanl.fetch_jobs())
-    all_jobs.extend(sri.fetch_jobs())
-    all_jobs.extend(llmit.fetch_jobs())
-    all_jobs.extend(swri.fetch_jobs())
-    all_jobs.extend(umich.fetch_jobs())
+    for module, name in sites:
+        jobs = module.fetch_jobs()
+        new_jobs = job_db.add_jobs(name, jobs, db)
+        if new_jobs:
+            logging.info(f"New jobs for {name}:")
+            for job in new_jobs:
+                logging.info(f"  {job['title']} | {job['url']}")
+        all_jobs.extend(jobs)
+
+    job_db.save_db(db)
 
 if __name__ == "__main__":
     run_all()


### PR DESCRIPTION
## Summary
- store seen jobs across runs in `jobs_db.yaml`
- log new postings when they appear
- document the persistent job database
- ignore the generated database file

## Testing
- `python -m compileall -q main.py sites utils job_db.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470c10894c8332af3f27ad67a2cec2